### PR TITLE
using prometheus-client-mmap

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,27 +2,26 @@ name: Ruby
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["rack2and3"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["rack2and3"]
 
 permissions:
   contents: read
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: bundle exec rake
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 Gemfile.lock
 *gemfile.lock
 /.idea/
+/vendor

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -3,7 +3,7 @@
 require "benchmark"
 require "rack"
 require "prometheus/client"
-require "prometheus/middleware/exporter"
+require "prometheus/client/rack/exporter"
 require "sidekiq"
 require "sidekiq/api"
 require "webrick"
@@ -245,7 +245,7 @@ module SidekiqPrometheus
     @_metrics_server ||= Thread.new do
       webrick_handler.run(
         Rack::Builder.new {
-          use Prometheus::Middleware::Exporter, registry: SidekiqPrometheus.registry
+          use Prometheus::Client::Rack::Exporter, registry: SidekiqPrometheus.registry
           run ->(_) { [301, {"Location" => "/metrics"}, []] }
         },
         **opts

--- a/lib/sidekiq_prometheus/job_metrics.rb
+++ b/lib/sidekiq_prometheus/job_metrics.rb
@@ -20,26 +20,26 @@ class SidekiqPrometheus::JobMetrics
       # In case the labels have changed after the worker perform method has been called
       labels.merge!(custom_labels(worker))
 
-      registry[:sidekiq_job_duration].observe(duration, labels: labels)
-      registry[:sidekiq_job_success].increment(labels: labels)
+      registry[:sidekiq_job_duration].observe(labels, duration)
+      registry[:sidekiq_job_success].increment(labels)
 
       if SidekiqPrometheus.gc_metrics_enabled?
         allocated = GC.stat(:total_allocated_objects) - before
-        registry[:sidekiq_job_allocated_objects].observe(allocated, labels: labels)
+        registry[:sidekiq_job_allocated_objects].observe(labels, allocated)
       end
 
       result
     rescue => e
       if defined?(::Sidekiq::Limiter::OverLimit) && e.instance_of?(::Sidekiq::Limiter::OverLimit)
-        registry[:sidekiq_job_over_limit].increment(labels: labels)
+        registry[:sidekiq_job_over_limit].increment(labels)
       else
         err_label = {error_class: e.class.to_s}
-        registry[:sidekiq_job_failed].increment(labels: err_label.merge(labels))
+        registry[:sidekiq_job_failed].increment(err_label.merge(labels))
       end
 
       raise e
     ensure
-      registry[:sidekiq_job_count].increment(labels: labels)
+      registry[:sidekiq_job_count].increment(labels)
     end
   end
 

--- a/lib/sidekiq_prometheus/metrics.rb
+++ b/lib/sidekiq_prometheus/metrics.rb
@@ -167,25 +167,31 @@ module SidekiqPrometheus::Metrics
     all_preset_labels = preset_labels.dup
     all_preset_labels.merge!(SidekiqPrometheus.preset_labels) if SidekiqPrometheus.preset_labels
 
-    # Aggregate all labels
-    all_labels = labels | SidekiqPrometheus.custom_labels.fetch(name, []) | all_preset_labels.keys
-
-    options = {docstring: docstring,
-               labels: all_labels,
-               preset_labels: all_preset_labels}
-
-    options[:buckets] = buckets if buckets
-
-    metric = registry.send(type, name.to_sym, **options)
-
+    # mmap version metric doesn't have "required labels" (labels arg here) concept
+    # their metric init signature is only name, docstring and labels_hash
+    # Example:
+    # counter = Prometheus::Client::Counter.new(:service_requests_total, 'doc string', {service: '2323'})
+    # counter.increment({ service: 'bar' }, 5)
+    #
+    # So here we just combine all the labels into all_preset_labels
+    # then pass metric as the single labels_hash arg
     init_label_sets = SidekiqPrometheus.init_label_sets.fetch(name, [])
-    init_label_sets.each { |label_set| metric.init_label_set(label_set) }
+    init_label_sets.each { |label_set| all_preset_labels.merge!(label_set) }
 
-    metric
+    # Because mmap version uses positional arg
+    # So we pass the extra histogram bucket if there is any
+    if type == :histogram && buckets
+      # send buckets option
+      registry.send(type, name.to_sym, docstring, all_preset_labels, buckets)
+    else
+      registry.send(type, name.to_sym, docstring, all_preset_labels)
+    end
   end
 
   def unregister(name:)
-    registry.unregister(name.to_sym)
+    # metric mmap doesn't support unregister
+    # registry.unregister(name.to_sym)
+    false
   end
 
   class InvalidMetricType < StandardError; end

--- a/lib/sidekiq_prometheus/metrics.rb
+++ b/lib/sidekiq_prometheus/metrics.rb
@@ -191,7 +191,7 @@ module SidekiqPrometheus::Metrics
   def unregister(name:)
     # metric mmap doesn't support unregister
     # registry.unregister(name.to_sym)
-    false
+    nil
   end
 
   class InvalidMetricType < StandardError; end

--- a/lib/sidekiq_prometheus/periodic_metrics.rb
+++ b/lib/sidekiq_prometheus/periodic_metrics.rb
@@ -87,13 +87,13 @@ class SidekiqPrometheus::PeriodicMetrics
   def report_gc_metrics
     stats = GC.stat
     GC_STATS[:counters].each do |stat|
-      SidekiqPrometheus["sidekiq_#{stat}"]&.increment(labels: {}, by: stats[stat])
+      SidekiqPrometheus["sidekiq_#{stat}"]&.increment({}, stats[stat])
     end
     GC_STATS[:gauges].each do |stat|
-      SidekiqPrometheus["sidekiq_#{stat}"]&.set(stats[stat], labels: {})
+      SidekiqPrometheus["sidekiq_#{stat}"]&.set({}, stats[stat])
     end
 
-    SidekiqPrometheus[:sidekiq_rss]&.set(rss, labels: {})
+    SidekiqPrometheus[:sidekiq_rss]&.set({}, rss)
   end
 
   ##
@@ -101,12 +101,12 @@ class SidekiqPrometheus::PeriodicMetrics
   def report_global_metrics
     current_stats = sidekiq_stats.new
     GLOBAL_STATS.each do |stat|
-      SidekiqPrometheus["sidekiq_#{stat}"]&.set(current_stats.send(stat), labels: {})
+      SidekiqPrometheus["sidekiq_#{stat}"]&.set({}, current_stats.send(stat))
     end
 
     sidekiq_queue.all.each do |queue|
-      SidekiqPrometheus[:sidekiq_enqueued]&.set(queue.size, labels: {queue: queue.name})
-      SidekiqPrometheus[:sidekiq_queue_latency]&.observe(queue.latency, labels: {queue: queue.name})
+      SidekiqPrometheus[:sidekiq_enqueued]&.set({queue: queue.name}, queue.size)
+      SidekiqPrometheus[:sidekiq_queue_latency]&.observe({queue: queue.name}, queue.latency)
     end
   end
 
@@ -126,15 +126,15 @@ class SidekiqPrometheus::PeriodicMetrics
     return if redis_info.nil?
 
     REDIS_STATS.each do |stat|
-      SidekiqPrometheus["sidekiq_redis_#{stat}"]&.set(redis_info[stat].to_i, labels: {})
+      SidekiqPrometheus["sidekiq_redis_#{stat}"]&.set({}, redis_info[stat].to_i)
     end
 
     db_stats = redis_info.select { |k, _v| k.match(/^db/) }
     db_stats.each do |db, stat|
       label = {database: db}
       values = stat.scan(/\d+/)
-      SidekiqPrometheus[:sidekiq_redis_keys]&.set(values[0].to_i, labels: label)
-      SidekiqPrometheus[:sidekiq_redis_expires]&.set(values[1].to_i, labels: label)
+      SidekiqPrometheus[:sidekiq_redis_keys]&.set(label, values[0].to_i)
+      SidekiqPrometheus[:sidekiq_redis_expires]&.set(label, values[1].to_i)
     end
   end
 

--- a/lib/sidekiq_prometheus/version.rb
+++ b/lib/sidekiq_prometheus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPrometheus
-  VERSION = "2.1.0"
+  VERSION = "2.0.1.1"
 end

--- a/lib/sidekiq_prometheus/version.rb
+++ b/lib/sidekiq_prometheus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPrometheus
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "standard"
 
-  spec.add_runtime_dependency "prometheus-client", ">= 2.0"
-  spec.add_runtime_dependency "rack", "> 2.0", "~> 3.0"
+  spec.add_runtime_dependency "prometheus-client-mmap", "~> 1.1"
+  spec.add_runtime_dependency "rack", "~> 2.2"
   spec.add_runtime_dependency "redis"
   spec.add_runtime_dependency "sidekiq", "> 5.1"
   spec.add_runtime_dependency "webrick"

--- a/spec/sidekiq_prometheus/job_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/job_metrics_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
         expect(registry).not_to have_received(:get).with(:sidekiq_job_duration)
         expect(registry).not_to have_received(:get).with(:sidekiq_job_success)
 
-        expect(metric).to have_received(:increment).once.with(labels: labels)
-        expect(metric).to have_received(:increment).once.with(labels: labels.merge(error_class: "StandardError"))
+        expect(metric).to have_received(:increment).once.with(labels)
+        expect(metric).to have_received(:increment).once.with(labels.merge(error_class: "StandardError"))
         expect(metric).not_to have_received(:observe)
       end
     end
@@ -73,8 +73,8 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
         expect(registry).to have_received(:get).with(:sidekiq_job_success)
         expect(registry).to have_received(:get).with(:sidekiq_job_allocated_objects)
 
-        expect(metric).to have_received(:increment).twice.with(labels: labels)
-        expect(metric).to have_received(:observe).twice.with(kind_of(Numeric), labels: labels)
+        expect(metric).to have_received(:increment).twice.with(labels)
+        expect(metric).to have_received(:observe).twice.with(labels, kind_of(Numeric))
       end
 
       it "returns the result from the yielded block" do
@@ -98,8 +98,8 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
         expect(registry).not_to have_received(:get).with(:sidekiq_job_duration)
         expect(registry).not_to have_received(:get).with(:sidekiq_job_success)
 
-        expect(metric).to have_received(:increment).once.with(labels: failed_labels)
-        expect(metric).to have_received(:increment).once.with(labels: labels)
+        expect(metric).to have_received(:increment).once.with(failed_labels)
+        expect(metric).to have_received(:increment).once.with(labels)
         expect(metric).not_to have_received(:observe)
       end
 
@@ -115,7 +115,7 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
         expect(registry).not_to have_received(:get).with(:sidekiq_job_duration)
         expect(registry).not_to have_received(:get).with(:sidekiq_job_success)
 
-        expect(metric).to have_received(:increment).twice.with(labels: labels)
+        expect(metric).to have_received(:increment).twice.with(labels)
         expect(metric).not_to have_received(:observe)
       end
 
@@ -135,8 +135,8 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
           expect(registry).to have_received(:get).with(:sidekiq_job_success)
           expect(registry).to have_received(:get).with(:sidekiq_job_allocated_objects)
 
-          expect(metric).to have_received(:increment).twice.with(labels: labels)
-          expect(metric).to have_received(:observe).twice.with(kind_of(Numeric), labels: labels)
+          expect(metric).to have_received(:increment).twice.with(labels)
+          expect(metric).to have_received(:observe).twice.with(labels, kind_of(Numeric))
         end
       end
     end

--- a/spec/sidekiq_prometheus/metrics_spec.rb
+++ b/spec/sidekiq_prometheus/metrics_spec.rb
@@ -60,16 +60,12 @@ RSpec.describe SidekiqPrometheus::Metrics do
 
       subject { described_class.get(:a_metric) }
 
-      it "registers a metric with aggregated labels from preset_labels and the method parameter labels" do
-        expect(subject.instance_variable_get(:@labels)).to be == %i[label1 label2 service1 service2]
-      end
-
-      it "raises InvalidLabelSetError error if any required label is missing" do
-        expect { subject.increment }.to raise_error(Prometheus::Client::LabelSetValidator::InvalidLabelSetError)
+      it "registers a metric with base labels from preset_labels and the method parameter labels" do
+        expect(subject.instance_variable_get(:@base_labels)).to be == {service1: "hello world", service2: "hello world 2"}
       end
 
       it "records a new data" do
-        subject.increment(labels: {label1: "label1", label2: "label2"})
+        subject.increment({label1: "label1", label2: "label2"})
       end
     end
 
@@ -88,24 +84,13 @@ RSpec.describe SidekiqPrometheus::Metrics do
           a_metric: [{label1: "value1", label2: "value1"}, {label1: "value1", label2: "value2"}]
         }
 
-        expect(subject.values).to be == {
-          {label1: "value1", label2: "value1"} => 0.0,
-          {label1: "value1", label2: "value2"} => 0.0
-        }
+        expect(subject.base_labels).to eq({label1: "value1", label2: "value2"})
       end
 
       it "skips initialization when label sets are not provided" do
         SidekiqPrometheus.init_label_sets = {}
 
         expect(subject.values).to be == {}
-      end
-
-      it "raises InvalidLabelSetError error if any required label is missing" do
-        SidekiqPrometheus.init_label_sets = {
-          a_metric: [{label1: "value1"}]
-        }
-
-        expect { subject }.to raise_error(Prometheus::Client::LabelSetValidator::InvalidLabelSetError)
       end
     end
   end
@@ -134,18 +119,6 @@ RSpec.describe SidekiqPrometheus::Metrics do
 
       described_class::SIDEKIQ_GLOBAL_METRICS.each do |metric|
         expect(described_class.get(metric[:name])).not_to be nil
-      end
-    end
-  end
-
-  describe "unregister_sidekiq_global_metrics" do
-    it "unregisters global metrics" do
-      described_class.register_sidekiq_global_metrics
-
-      described_class.unregister_sidekiq_global_metrics
-
-      described_class::SIDEKIQ_GLOBAL_METRICS.each do |metric|
-        expect(described_class.get(metric[:name])).to be nil
       end
     end
   end

--- a/spec/sidekiq_prometheus/periodic_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/periodic_metrics_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
 
       reporter.report_gc_metrics
 
-      expect(metric).to have_received(:increment).with(by: kind_of(Numeric), labels: {}).exactly(described_class::GC_STATS[:counters].size).times
+      expect(metric).to have_received(:increment).with({}, kind_of(Numeric)).exactly(described_class::GC_STATS[:counters].size).times
       # plus one because rss
-      expect(metric).to have_received(:set).with(kind_of(Numeric), labels: {}).exactly(described_class::GC_STATS[:gauges].size + 1).times
+      expect(metric).to have_received(:set).with({}, kind_of(Numeric)).exactly(described_class::GC_STATS[:gauges].size + 1).times
     end
   end
 
@@ -88,12 +88,12 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
         expect(sidekiq_stats).to have_received(stat)
       end
 
-      expect(metric).to have_received(:set).with(num, labels: {}).exactly(described_class::GLOBAL_STATS.size).times
+      expect(metric).to have_received(:set).with({}, num).exactly(described_class::GLOBAL_STATS.size).times
 
-      expect(metric).to have_received(:set).with(queue.size, labels: {queue: queue.name})
-      expect(metric).to have_received(:observe).with(queue.latency, labels: {queue: queue.name})
-      expect(metric).to have_received(:set).with(another_queue.size, labels: {queue: another_queue.name})
-      expect(metric).to have_received(:observe).with(another_queue.latency, labels: {queue: another_queue.name})
+      expect(metric).to have_received(:set).with({queue: queue.name}, queue.size)
+      expect(metric).to have_received(:observe).with({queue: queue.name}, queue.latency)
+      expect(metric).to have_received(:set).with({queue: another_queue.name}, another_queue.size)
+      expect(metric).to have_received(:observe).with({queue: another_queue.name}, another_queue.latency)
     end
   end
 
@@ -126,13 +126,13 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
 
       reporter.report_redis_metrics
 
-      expect(metric).to have_received(:set).with(1, labels: {})
-      expect(metric).to have_received(:set).with(1024, labels: {})
-      expect(metric).to have_received(:set).with(2048, labels: {})
-      expect(metric).to have_received(:set).with(1, labels: {database: "db0"})
-      expect(metric).to have_received(:set).with(0, labels: {database: "db0"})
-      expect(metric).to have_received(:set).with(100, labels: {database: "db1"})
-      expect(metric).to have_received(:set).with(10, labels: {database: "db1"})
+      expect(metric).to have_received(:set).with({}, 1)
+      expect(metric).to have_received(:set).with({}, 1024)
+      expect(metric).to have_received(:set).with({}, 2048)
+      expect(metric).to have_received(:set).with({database: "db0"}, 1)
+      expect(metric).to have_received(:set).with({database: "db0"}, 0)
+      expect(metric).to have_received(:set).with({database: "db1"}, 100)
+      expect(metric).to have_received(:set).with({database: "db1"}, 10)
     end
   end
 

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -172,6 +172,10 @@ RSpec.describe SidekiqPrometheus do
         SidekiqPrometheus::Metrics.register_sidekiq_job_metrics
         thread = described_class.metrics_server
 
+        # simulate count increase
+        # otherwise mmap version will not export registered only metric
+        SidekiqPrometheus["sidekiq_job_count"].increment
+
         sleep 1
 
         http = Net::HTTP.new(SidekiqPrometheus.metrics_host, SidekiqPrometheus.metrics_port)


### PR DESCRIPTION
This PR uses https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap rather than https://github.com/prometheus/client_ruby

Key differences between these two client:

- `prometheus-client-mmap`'s metric init signature uses positional args rather than keyword args
- `prometheus-client-mmap`'s metrics signature always put labels as the first arg and value as second (positional args)
- `prometheus-client-mmap`'s registry do not support `unregister` thus muted the method

Needs to target to branch `rack2and3` because we are still on 2
